### PR TITLE
Bundle an SBOM inside artemis-console WAR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ artemis-console-extension/artemis-extension/node/**/*
 artemis-console-extension/artemis-extension/packages/artemis-console-plugin/node_modules/
 artemis-console-extension/artemis-extension/app/node_modules/**/*
 
+# generated SBOM
+artemis-console-extension/artemis-extension/bom.cdx.json
+
 # yarn (zero-installs)
 artemis-console-extension/artemis-extension/.yarn/install-state.gz
 .yarn/**

--- a/artemis-console-extension/artemis-extension/package.json
+++ b/artemis-console-extension/artemis-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artemis-console-monorepo",
-  "version": "0",
+  "version": "0.0.0",
   "description": "Artemis Console Monorepo",
   "license": "Apache-2.0",
   "private": true,

--- a/artemis-console-extension/pom.xml
+++ b/artemis-console-extension/pom.xml
@@ -78,6 +78,36 @@
                             <arguments>yarn build</arguments>
                         </configuration>
                     </execution>
+                    <!--
+                        Generate a CycloneDX SBOM for all npm dependencies
+                        using the official CycloneDX Yarn plugin. Resolves
+                        licenses from package.json in node_modules.
+                    -->
+                    <execution>
+                        <id>generate-sbom</id>
+                        <goals>
+                            <goal>corepack</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>yarn workspace artemis-console-app dlx @cyclonedx/yarn-plugin-cyclonedx@3.3.3 --spec-version 1.6 --output-file ../bom.cdx.json</arguments>
+                        </configuration>
+                    </execution>
+                    <!--
+                        Enrich the SBOM:
+                        - add SHA-512 hashes from yarn.lock;
+                        - add evidence.identity;
+                        - -prod-only excludes non-production dependencies entirely;
+                        - omitting -prod-only sets scope=excluded for non-prod dependencies.
+                    -->
+                    <execution>
+                        <id>enrich-sbom</id>
+                        <goals>
+                            <goal>corepack</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>yarn dlx @cyberstamp/cdx-npm-enrich@${cdx-npm-enrich-version} --prod-only bom.cdx.json</arguments>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>yarn test</id>
                         <goals>
@@ -116,6 +146,12 @@
                                 <include>**/*</include>
                             </includes>
                             <followSymlinks>false</followSymlinks>
+                        </fileset>
+                        <fileset>
+                            <directory>${basedir}/${extension.path}</directory>
+                            <includes>
+                                <include>bom.cdx.json</include>
+                            </includes>
                         </fileset>
                     </filesets>
                 </configuration>

--- a/artemis-console-war/pom.xml
+++ b/artemis-console-war/pom.xml
@@ -76,6 +76,15 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-war</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>exploded</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
                 <nonFilteredFileExtensions>
                     <!-- default value contains jpg,jpeg,gif,bmp,png -->
@@ -92,8 +101,34 @@
                                 <include>**/*.*</include>
                             </includes>
                         </resource>
+                        <resource>
+                            <filtering>false</filtering>
+                            <directory>${project.build.directory}</directory>
+                            <targetPath>META-INF/sbom</targetPath>
+                            <includes>
+                                <include>bom.cdx.json</include>
+                            </includes>
+                        </resource>
                     </webResources>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>dev.cyberstamp.maven.assembly.sbom</groupId>
+                <artifactId>assembly-sbom-maven-plugin</artifactId>
+                <version>${assembly-sbom-maven-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <externalSboms>${project.basedir}/../artemis-console-extension/artemis-extension/bom.cdx.json</externalSboms>
+                            <outputFile>${project.build.directory}/bom.cdx.json</outputFile>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
         <node-version>v22.23.1</node-version>
         <yarn-version>v4.9.2</yarn-version>
         <frontend-maven-plugin-version>1.15.1</frontend-maven-plugin-version>
+        <assembly-sbom-maven-plugin-version>0.1.4</assembly-sbom-maven-plugin-version>
+        <cdx-npm-enrich-version>0.1.6</cdx-npm-enrich-version>
         <project.build.outputTimestamp>2026-04-27T13:23:57Z</project.build.outputTimestamp>
     </properties>
 
@@ -244,6 +246,9 @@
                             <exclude>**/tsconfig.json</exclude>
                             <exclude>**/artemis-extension/app/build/**</exclude>
                             <exclude>**/artemis-extension/packages/artemis-console-plugin/dist/**</exclude>
+
+                            <!-- Generated SBOM -->
+                            <exclude>**/bom.cdx.json</exclude>
                         </excludes>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
This PR adds SBOM generation to the Artemis Console WAR.
The SBOM bundled in the WAR will later be merged (or rather used as a source of NPM components) into the final Artemis distribution SBOM (see https://github.com/apache/artemis/pull/6600).

The original SBOM is generated using the Yarn CycloneDX plugin and then later enriched with https://github.com/cyberstamp/cdx-npm-enrich

The WAR SBOM is generated with https://github.com/cyberstamp/maven-assembly-sbom

I previously demoed it to @brusdev 